### PR TITLE
Std Curve View - allow for 1 or two underscores in column names

### DIFF
--- a/src/R/std_curve_view.R
+++ b/src/R/std_curve_view.R
@@ -3,9 +3,9 @@
 
 
 # get colunm indices based on their column names
-CONC_DPM_COL_INDEX = which(names(labkey.data) == "std__activity__dpm_" )
-INTENSITY_BKG_COL_INDEX = which(names(labkey.data) == "intensity_area__ql_mm2_" )
-AREA_COL_INDEX = which(names(labkey.data) == "area__mm2_")
+CONC_DPM_COL_INDEX = which(grepl ("std_{1,2}activity_{1,2}dpm_{1,2}", names(labkey.data), perl=TRUE))
+INTENSITY_BKG_COL_INDEX = which(grepl ("intensity_{1,2}area_{1,2}ql_{1,2}mm2_{1,2}", names(labkey.data), perl=TRUE))
+AREA_COL_INDEX = which(grepl ("area_{1,2}mm2_{1,2}", names(labkey.data), perl=TRUE))
 GROUP_COL_INDEX = which(names(labkey.data) == "grp")
 
 #Standardization line


### PR DESCRIPTION
sometimes there is only 1 underscore in the column names, sometimes
there are 2.  so now the script works in both cases.